### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ">=1.5.0"
+          terraform_version: ">=1.9.0"
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive -diff
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ">=1.5.0"
+          terraform_version: ">=1.9.0"
 
       - name: Terraform Init
         run: terraform init -backend=false
@@ -77,12 +77,12 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: ">=1.5.0"
+          terraform_version: ">=1.9.0"
 
       - name: Find and Validate Examples
         run: |
           if [ -d "examples" ]; then
-            for dir in examples/*/; do
+            for dir in examples/*/*/; do
               if [ -f "${dir}main.tf" ] || [ -f "${dir}versions.tf" ]; then
                 echo "::group::Validating ${dir}"
                 cd "${dir}"

--- a/README.md
+++ b/README.md
@@ -88,16 +88,16 @@ module "mod_operational_logging" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
@@ -105,9 +105,9 @@ module "mod_operational_logging" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_lz_management_resources"></a> [lz\_management\_resources](#module\_lz\_management\_resources) | Azure/alz-management/azurerm | ~> 0.1 |
-| <a name="module_mod_aa_diagnostic_settings"></a> [mod\_aa\_diagnostic\_settings](#module\_mod\_aa\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0 |
+| <a name="module_mod_aa_diagnostic_settings"></a> [mod\_aa\_diagnostic\_settings](#module\_mod\_aa\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
 | <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | >= 1.0.0 |
-| <a name="module_mod_log_diagnostic_settings"></a> [mod\_log\_diagnostic\_settings](#module\_mod\_log\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0 |
+| <a name="module_mod_log_diagnostic_settings"></a> [mod\_log\_diagnostic\_settings](#module\_mod\_log\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
 | <a name="module_mod_loganalytics_sa"></a> [mod\_loganalytics\_sa](#module\_mod\_loganalytics\_sa) | azurenoops/overlays-storage-account/azurerm | >= 0.1.0 |
 | <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | azurenoops/overlays-resource-group/azurerm | >= 1.0.1 |
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/POps-Rox/tf-az-overlays-managementlogging/pulls)
 [![Maintained](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/POps-Rox/tf-az-overlays-managementlogging/graphs/commit-activity)
-[![Terraform](https://img.shields.io/badge/Terraform-%3E%3D1.5-623CE4.svg?logo=terraform)](https://www.terraform.io)
+[![Terraform](https://img.shields.io/badge/Terraform-%3E%3D1.9-623CE4.svg?logo=terraform)](https://www.terraform.io)
 <!-- BADGES:END -->
 
 # Azure NoOps Management Logging Terraform Module

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,16 +88,16 @@ module "mod_operational_logging" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
@@ -105,9 +105,9 @@ module "mod_operational_logging" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_lz_management_resources"></a> [lz\_management\_resources](#module\_lz\_management\_resources) | Azure/alz-management/azurerm | ~> 0.1 |
-| <a name="module_mod_aa_diagnostic_settings"></a> [mod\_aa\_diagnostic\_settings](#module\_mod\_aa\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0 |
+| <a name="module_mod_aa_diagnostic_settings"></a> [mod\_aa\_diagnostic\_settings](#module\_mod\_aa\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
 | <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | >= 1.0.0 |
-| <a name="module_mod_log_diagnostic_settings"></a> [mod\_log\_diagnostic\_settings](#module\_mod\_log\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0 |
+| <a name="module_mod_log_diagnostic_settings"></a> [mod\_log\_diagnostic\_settings](#module\_mod\_log\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
 | <a name="module_mod_loganalytics_sa"></a> [mod\_loganalytics\_sa](#module\_mod\_loganalytics\_sa) | azurenoops/overlays-storage-account/azurerm | >= 0.1.0 |
 | <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | azurenoops/overlays-resource-group/azurerm | >= 1.0.1 |
 

--- a/examples/Commerical/workspace_aa/main.tf
+++ b/examples/Commerical/workspace_aa/main.tf
@@ -1,8 +1,3 @@
-# Azurerm provider configuration
-provider "azurerm" {
-  features {}
-}
-
 module "mod_logging" {
   source = "../../.." # Path to the root of the repository
 

--- a/examples/Commerical/workspace_aa/versions.tf
+++ b/examples/Commerical/workspace_aa/versions.tf
@@ -1,6 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   features {

--- a/examples/Government/workspace_aa/main.tf
+++ b/examples/Government/workspace_aa/main.tf
@@ -1,8 +1,3 @@
-# Azurerm provider configuration
-provider "azurerm" {
-  features {}
-}
-
 module "mod_logging" {
   source = "../../.." # Path to the root of the repository
 

--- a/examples/Government/workspace_aa/versions.tf
+++ b/examples/Government/workspace_aa/versions.tf
@@ -1,6 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+  }
+}
+
 # Azurerm provider configuration
 provider "azurerm" {
   features {

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"


### PR DESCRIPTION
# Describe your changes

Modernize version constraints to current standards and fix consistency issues across all configuration files.

### Changes
- Terraform `>= 1.3` → `>= 1.9`
- azurerm `~> 3.x` → `~> 3.116`
- azurenoopsutils → `~> 1.0.4`
- Fix README.md Terraform badge from `>= 1.5` to `>= 1.9`
- Fix `.github/workflows/ci.yml` `terraform_version` in all 3 jobs from `>=1.5.0` to `>=1.9.0`
- Fix CI plan job glob from `examples/*/` to `examples/*/*/` so nested example directories are discovered
- Remove duplicate `provider "azurerm"` blocks from example `main.tf` files (kept in `versions.tf`)
- Add `terraform {}` block with `required_version = ">= 1.9"` and `required_providers` to both example `versions.tf` files
- Updated documentation

## Issue number

11

## Checklist before requesting a review

- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.