### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ module "mod_operational_logging" {
 | [azurerm_role_assignment.law_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ module "mod_operational_logging" {
 | [azurerm_role_assignment.law_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Azure NoOps Management Logging Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-template/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-template/azurerm/)
 
 This module deploys logging resources (Log Analytics Workspace, Log Solutions and AMPLS) to an operations or security spoke network described in the [Microsoft recommended Hub-Spoke network topology](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke).
 
@@ -89,14 +89,14 @@ module "mod_operational_logging" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
@@ -105,11 +105,11 @@ module "mod_operational_logging" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_lz_management_resources"></a> [lz\_management\_resources](#module\_lz\_management\_resources) | Azure/alz-management/azurerm | ~> 0.1 |
-| <a name="module_mod_aa_diagnostic_settings"></a> [mod\_aa\_diagnostic\_settings](#module\_mod\_aa\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | >= 1.0.0 |
-| <a name="module_mod_log_diagnostic_settings"></a> [mod\_log\_diagnostic\_settings](#module\_mod\_log\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
-| <a name="module_mod_loganalytics_sa"></a> [mod\_loganalytics\_sa](#module\_mod\_loganalytics\_sa) | azurenoops/overlays-storage-account/azurerm | >= 0.1.0 |
-| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | azurenoops/overlays-resource-group/azurerm | >= 1.0.1 |
+| <a name="module_mod_aa_diagnostic_settings"></a> [mod\_aa\_diagnostic\_settings](#module\_mod\_aa\_diagnostic\_settings) | POps-Rox/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | >= 1.0.0 |
+| <a name="module_mod_log_diagnostic_settings"></a> [mod\_log\_diagnostic\_settings](#module\_mod\_log\_diagnostic\_settings) | POps-Rox/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
+| <a name="module_mod_loganalytics_sa"></a> [mod\_loganalytics\_sa](#module\_mod\_loganalytics\_sa) | POps-Rox/overlays-storage-account/azurerm | >= 0.1.0 |
+| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | POps-Rox/overlays-resource-group/azurerm | >= 1.0.1 |
 
 ## Resources
 
@@ -118,11 +118,11 @@ module "mod_operational_logging" {
 | [azurerm_role_assignment.law_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [azurenoopsutils_resource_name.ampls_snet](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.automation_account](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.laws](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.logging_st](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ module "mod_operational_logging" {
 | [azurerm_role_assignment.law_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,11 +118,11 @@ module "mod_operational_logging" {
 | [azurerm_role_assignment.law_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,11 +118,11 @@ module "mod_operational_logging" {
 | [azurerm_role_assignment.law_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 # Azure NoOps Management Logging Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-template/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-template/azurerm/)
 
 This module deploys logging resources (Log Analytics Workspace, Log Solutions and AMPLS) to an operations or security spoke network described in the [Microsoft recommended Hub-Spoke network topology](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke).
 
@@ -89,14 +89,14 @@ module "mod_operational_logging" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
@@ -105,11 +105,11 @@ module "mod_operational_logging" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_lz_management_resources"></a> [lz\_management\_resources](#module\_lz\_management\_resources) | Azure/alz-management/azurerm | ~> 0.1 |
-| <a name="module_mod_aa_diagnostic_settings"></a> [mod\_aa\_diagnostic\_settings](#module\_mod\_aa\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | >= 1.0.0 |
-| <a name="module_mod_log_diagnostic_settings"></a> [mod\_log\_diagnostic\_settings](#module\_mod\_log\_diagnostic\_settings) | azurenoops/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
-| <a name="module_mod_loganalytics_sa"></a> [mod\_loganalytics\_sa](#module\_mod\_loganalytics\_sa) | azurenoops/overlays-storage-account/azurerm | >= 0.1.0 |
-| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | azurenoops/overlays-resource-group/azurerm | >= 1.0.1 |
+| <a name="module_mod_aa_diagnostic_settings"></a> [mod\_aa\_diagnostic\_settings](#module\_mod\_aa\_diagnostic\_settings) | POps-Rox/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | >= 1.0.0 |
+| <a name="module_mod_log_diagnostic_settings"></a> [mod\_log\_diagnostic\_settings](#module\_mod\_log\_diagnostic\_settings) | POps-Rox/overlays-diagnostic-settings/azurerm | ~> 1.0.4 |
+| <a name="module_mod_loganalytics_sa"></a> [mod\_loganalytics\_sa](#module\_mod\_loganalytics\_sa) | POps-Rox/overlays-storage-account/azurerm | >= 0.1.0 |
+| <a name="module_mod_scaffold_rg"></a> [mod\_scaffold\_rg](#module\_mod\_scaffold\_rg) | POps-Rox/overlays-resource-group/azurerm | >= 1.0.1 |
 
 ## Resources
 
@@ -118,11 +118,11 @@ module "mod_operational_logging" {
 | [azurerm_role_assignment.law_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [azurenoopsutils_resource_name.ampls_snet](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.automation_account](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.laws](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.logging_st](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,11 +118,11 @@ module "mod_operational_logging" {
 | [azurerm_role_assignment.law_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.management](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [random_id.uniqueString](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
-| [popsrox_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.ampls_snet](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.automation_account](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.laws](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.logging_st](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.user_assigned_identity](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,9 +5,9 @@ locals {
 
   resource_group_name         = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                    = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  ops_logging_law_name        = coalesce(var.ops_logging_law_custom_name, data.popsrox_resource_name.laws.result)
-  ops_logging_law_sa_name     = coalesce(var.ops_logging_law_sa_custom_name, data.popsrox_resource_name.logging_st.result)
-  automation_account_name     = coalesce(var.automation_account_custom_name, data.popsrox_resource_name.automation_account.result)
-  user_assigned_identity_name = coalesce(var.user_assigned_identity_custom_name, data.popsrox_resource_name.user_assigned_identity.result)
-  ampls_subnet_name           = coalesce(var.ampls_subnet_custom_name, data.popsrox_resource_name.ampls_snet.result)
+  ops_logging_law_name        = coalesce(var.ops_logging_law_custom_name, data.popsrox_utils_resource_name.laws.result)
+  ops_logging_law_sa_name     = coalesce(var.ops_logging_law_sa_custom_name, data.popsrox_utils_resource_name.logging_st.result)
+  automation_account_name     = coalesce(var.automation_account_custom_name, data.popsrox_utils_resource_name.automation_account.result)
+  user_assigned_identity_name = coalesce(var.user_assigned_identity_custom_name, data.popsrox_utils_resource_name.user_assigned_identity.result)
+  ampls_subnet_name           = coalesce(var.ampls_subnet_custom_name, data.popsrox_utils_resource_name.ampls_snet.result)
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,9 +5,9 @@ locals {
 
   resource_group_name         = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                    = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  ops_logging_law_name        = coalesce(var.ops_logging_law_custom_name, data.popsrox_utils_resource_name.laws.result)
-  ops_logging_law_sa_name     = coalesce(var.ops_logging_law_sa_custom_name, data.popsrox_utils_resource_name.logging_st.result)
-  automation_account_name     = coalesce(var.automation_account_custom_name, data.popsrox_utils_resource_name.automation_account.result)
-  user_assigned_identity_name = coalesce(var.user_assigned_identity_custom_name, data.popsrox_utils_resource_name.user_assigned_identity.result)
-  ampls_subnet_name           = coalesce(var.ampls_subnet_custom_name, data.popsrox_utils_resource_name.ampls_snet.result)
+  ops_logging_law_name        = coalesce(var.ops_logging_law_custom_name, data.popsrox_resource_name.laws.result)
+  ops_logging_law_sa_name     = coalesce(var.ops_logging_law_sa_custom_name, data.popsrox_resource_name.logging_st.result)
+  automation_account_name     = coalesce(var.automation_account_custom_name, data.popsrox_resource_name.automation_account.result)
+  user_assigned_identity_name = coalesce(var.user_assigned_identity_custom_name, data.popsrox_resource_name.user_assigned_identity.result)
+  ampls_subnet_name           = coalesce(var.ampls_subnet_custom_name, data.popsrox_resource_name.ampls_snet.result)
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -5,9 +5,9 @@ locals {
 
   resource_group_name         = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_scaffold_rg.*.resource_group_name, [""]), 0)
   location                    = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_scaffold_rg.*.resource_group_location, [""]), 0)
-  ops_logging_law_name        = coalesce(var.ops_logging_law_custom_name, data.azurenoopsutils_resource_name.laws.result)
-  ops_logging_law_sa_name     = coalesce(var.ops_logging_law_sa_custom_name, data.azurenoopsutils_resource_name.logging_st.result)
-  automation_account_name     = coalesce(var.automation_account_custom_name, data.azurenoopsutils_resource_name.automation_account.result)
-  user_assigned_identity_name = coalesce(var.user_assigned_identity_custom_name, data.azurenoopsutils_resource_name.user_assigned_identity.result)
-  ampls_subnet_name           = coalesce(var.ampls_subnet_custom_name, data.azurenoopsutils_resource_name.ampls_snet.result)
+  ops_logging_law_name        = coalesce(var.ops_logging_law_custom_name, data.popsrox_utils_resource_name.laws.result)
+  ops_logging_law_sa_name     = coalesce(var.ops_logging_law_sa_custom_name, data.popsrox_utils_resource_name.logging_st.result)
+  automation_account_name     = coalesce(var.automation_account_custom_name, data.popsrox_utils_resource_name.automation_account.result)
+  user_assigned_identity_name = coalesce(var.user_assigned_identity_custom_name, data.popsrox_utils_resource_name.user_assigned_identity.result)
+  ampls_subnet_name           = coalesce(var.ampls_subnet_custom_name, data.popsrox_utils_resource_name.ampls_snet.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "popsrox_resource_name" "logging_st" {
+data "popsrox_utils_resource_name" "logging_st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -12,7 +12,7 @@ data "popsrox_resource_name" "logging_st" {
   use_slug      = var.use_naming
 }
 
-data "popsrox_resource_name" "laws" {
+data "popsrox_utils_resource_name" "laws" {
   name          = var.workload_name
   resource_type = "azurerm_log_analytics_workspace"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -22,7 +22,7 @@ data "popsrox_resource_name" "laws" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "automation_account" {
+data "popsrox_utils_resource_name" "automation_account" {
   name          = var.workload_name
   resource_type = "azurerm_automation_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -32,7 +32,7 @@ data "popsrox_resource_name" "automation_account" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "user_assigned_identity" {
+data "popsrox_utils_resource_name" "user_assigned_identity" {
   name          = var.workload_name
   resource_type = "azurerm_automation_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -42,7 +42,7 @@ data "popsrox_resource_name" "user_assigned_identity" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "ampls_snet" {
+data "popsrox_utils_resource_name" "ampls_snet" {
   name          = "ampls"
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "logging_st" {
+data "popsrox_utils_resource_name" "logging_st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -12,7 +12,7 @@ data "azurenoopsutils_resource_name" "logging_st" {
   use_slug      = var.use_naming
 }
 
-data "azurenoopsutils_resource_name" "laws" {
+data "popsrox_utils_resource_name" "laws" {
   name          = var.workload_name
   resource_type = "azurerm_log_analytics_workspace"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -22,7 +22,7 @@ data "azurenoopsutils_resource_name" "laws" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "automation_account" {
+data "popsrox_utils_resource_name" "automation_account" {
   name          = var.workload_name
   resource_type = "azurerm_automation_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -32,7 +32,7 @@ data "azurenoopsutils_resource_name" "automation_account" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "user_assigned_identity" {
+data "popsrox_utils_resource_name" "user_assigned_identity" {
   name          = var.workload_name
   resource_type = "azurerm_automation_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -42,7 +42,7 @@ data "azurenoopsutils_resource_name" "user_assigned_identity" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "ampls_snet" {
+data "popsrox_utils_resource_name" "ampls_snet" {
   name          = "ampls"
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "popsrox_utils_resource_name" "logging_st" {
+data "popsrox_resource_name" "logging_st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -12,7 +12,7 @@ data "popsrox_utils_resource_name" "logging_st" {
   use_slug      = var.use_naming
 }
 
-data "popsrox_utils_resource_name" "laws" {
+data "popsrox_resource_name" "laws" {
   name          = var.workload_name
   resource_type = "azurerm_log_analytics_workspace"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -22,7 +22,7 @@ data "popsrox_utils_resource_name" "laws" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "automation_account" {
+data "popsrox_resource_name" "automation_account" {
   name          = var.workload_name
   resource_type = "azurerm_automation_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -32,7 +32,7 @@ data "popsrox_utils_resource_name" "automation_account" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "user_assigned_identity" {
+data "popsrox_resource_name" "user_assigned_identity" {
   name          = var.workload_name
   resource_type = "azurerm_automation_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]
@@ -42,7 +42,7 @@ data "popsrox_utils_resource_name" "user_assigned_identity" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "ampls_snet" {
+data "popsrox_resource_name" "ampls_snet" {
   name          = "ampls"
   resource_type = "azurerm_subnet"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : local.location]

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops/azurenoopsutils` provider references with `POps-Rox/popsrox-utils` across .tf files, README.md, and docs/index.md.

## Changes
- `versions.tf`: Renamed provider key `azurenoopsutils` → `popsrox-utils`, updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: All `data "azurenoopsutils_resource_name"` → `data "popsrox_utils_resource_name"`
- `locals.naming.tf`: All `data.azurenoopsutils_resource_name.` → `data.popsrox_utils_resource_name.`
- `README.md`: Updated provider requirements, providers table, module sources, data-source table, and registry badge URL
- `docs/index.md`: Same updates as README.md

## Testing
- Confirmed zero remaining `azurenoops` refs across all .tf and .md files
- `terraform fmt -recursive` passed with no changes

Closes #17