### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-managementlogging
+  name: terraform-az-overlays-managementlogging
   description: Terraform overlay module for Azure management logging (Log Analytics)
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-managementlogging
+    github.com/project-slug: POps-Rox/terraform-az-overlays-managementlogging
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-managementlogging
+    - url: https://github.com/POps-Rox/terraform-az-overlays-managementlogging
       title: GitHub Repository
       icon: github
 spec:

--- a/modules.management.logging.scaffolding.tf
+++ b/modules.management.logging.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_resource_group ? 1 : 0
 

--- a/modules.management.logging.storage.account.tf
+++ b/modules.management.logging.storage.account.tf
@@ -5,7 +5,7 @@
 # Hub Logging Storage Account Creation
 #----------------------------------------------------------
 module "mod_loganalytics_sa" {
-  source                       = "github.com/POps-Rox/tf-az-overlays-storageaccount"
+  source                       = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
   depends_on                   = [module.mod_scaffold_rg]
   existing_resource_group_name = local.resource_group_name
   storage_account_custom_name  = local.ops_logging_law_sa_name

--- a/resources.management.diagnostic.setting.tf
+++ b/resources.management.diagnostic.setting.tf
@@ -5,7 +5,7 @@
 # Operations Log Analytics Workspace Diagnostic Setting
 #----------------------------------------------------------
 module "mod_log_diagnostic_settings" {
-  source = "github.com/POps-Rox/tf-az-overlays-diagnosticsettings"
+  source = "github.com/POps-Rox/terraform-az-overlays-diagnosticsettings"
 
   # Resource Group, location, VNet and Subnet details
   location           = var.location
@@ -23,7 +23,7 @@ module "mod_log_diagnostic_settings" {
 # Automation Account Diagnostic Setting
 #----------------------------------------------------------
 module "mod_aa_diagnostic_settings" {
-  source = "github.com/POps-Rox/tf-az-overlays-diagnosticsettings"
+  source = "github.com/POps-Rox/terraform-az-overlays-diagnosticsettings"
 
   # Resource Group, location, VNet and Subnet details
   location           = var.location


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.